### PR TITLE
Refine admin interface layout and styles

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -14,16 +14,18 @@
           {% endif %}
         {% endwith %}
         <form method="post" action="{{ url_for('admin_login_post') }}">
-          <div class="mb-3">
-            <label class="form-label">Usuario</label>
-            <input class="form-control" name="user" required />
+          <div class="row g-3">
+            <div class="col-12">
+              <label class="form-label">Usuario</label>
+              <input class="form-control" name="user" required />
+            </div>
+            <div class="col-12">
+              <label class="form-label">Contraseña</label>
+              <input type="password" class="form-control" name="password" required />
+            </div>
           </div>
-          <div class="mb-3">
-            <label class="form-label">Contraseña</label>
-            <input type="password" class="form-control" name="password" required />
-          </div>
-          <div class="d-grid">
-            <button class="btn btn-dark" type="submit">Entrar</button>
+          <div class="d-grid mt-4">
+            <button class="btn btn-primary" type="submit">Entrar</button>
           </div>
         </form>
       </div>
@@ -31,72 +33,76 @@
   </div>
 </div>
 {% elif view == "panel" %}
-  <div class="d-flex align-items-center justify-content-between mb-3">
-    <h1 class="h5 m-0">Panel de registros</h1>
-    <div>
-      <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('admin_logout') }}">Salir</a>
-    </div>
-  </div>
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <div class="d-flex align-items-center justify-content-between mb-3">
+        <h1 class="h5 m-0">Panel de registros</h1>
+        <div>
+          <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('admin_logout') }}">Salir</a>
+        </div>
+      </div>
 
-  <form class="row g-2 align-items-end mb-3" method="get" action="{{ url_for('admin_panel') }}">
-    <div class="col-md-6">
-      <label class="form-label">Evento</label>
-      <select class="form-select" name="slug">
-        <option value="">— Selecciona —</option>
-        {% for e in eventos %}
-          <option value="{{ e.slug }}" {% if slug==e.slug %}selected{% endif %}>{{ e.titulo }} ({{ e.slug }})</option>
-        {% endfor %}
-      </select>
-    </div>
-    <div class="col-md-3">
-      <button class="btn btn-primary w-100" type="submit">Ver registros</button>
-    </div>
-    <div class="col-md-3">
-      {% if slug %}
-      <a class="btn btn-success w-100" href="{{ url_for('admin_export', slug=slug) }}">Exportar CSV</a>
-      {% else %}
-      <button class="btn btn-success w-100" type="button" disabled>Exportar CSV</button>
+      <form class="row g-2 align-items-end mb-3" method="get" action="{{ url_for('admin_panel') }}">
+        <div class="col-md-6">
+          <label class="form-label">Evento</label>
+          <select class="form-select" name="slug">
+            <option value="">— Selecciona —</option>
+            {% for e in eventos %}
+              <option value="{{ e.slug }}" {% if slug==e.slug %}selected{% endif %}>{{ e.titulo }} ({{ e.slug }})</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="col-md-3">
+          <button class="btn btn-primary w-100" type="submit">Ver registros</button>
+        </div>
+        <div class="col-md-3">
+          {% if slug %}
+          <a class="btn btn-success w-100" href="{{ url_for('admin_export', slug=slug) }}">Exportar CSV</a>
+          {% else %}
+          <button class="btn btn-success w-100" type="button" disabled>Exportar CSV</button>
+          {% endif %}
+        </div>
+      </form>
+
+      {% if registros %}
+      <div class="table-responsive">
+        <table class="table table-sm table-striped align-middle">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Nombre</th>
+              <th>Email</th>
+              <th>Teléfono</th>
+              <th>Institución</th>
+              <th>Carrera/Área</th>
+              <th>Consent.</th>
+              <th>Asistencia</th>
+              <th>Registrado</th>
+              <th>IP</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for r in registros %}
+            <tr>
+              <td>{{ loop.index }}</td>
+              <td>{{ r.nombre }} {{ r.apellidos }}</td>
+              <td>{{ r.email }}</td>
+              <td>{{ r.telefono or "" }}</td>
+              <td>{{ r.institucion or "" }}</td>
+              <td>{{ r.carrera_o_area or "" }}</td>
+              <td>{{ "Sí" if r.consentimiento else "No" }}</td>
+              <td>{{ r.asistencia_marcarda_en }}</td>
+              <td>{{ r.creado_en }}</td>
+              <td>{{ r.ip or "" }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% elif slug %}
+        <div class="alert alert-info">No hay registros para este evento.</div>
       {% endif %}
     </div>
-  </form>
-
-  {% if registros %}
-  <div class="table-responsive">
-    <table class="table table-sm table-striped align-middle">
-      <thead>
-        <tr>
-          <th>#</th>
-          <th>Nombre</th>
-          <th>Email</th>
-          <th>Teléfono</th>
-          <th>Institución</th>
-          <th>Carrera/Área</th>
-          <th>Consent.</th>
-          <th>Asistencia</th>
-          <th>Registrado</th>
-          <th>IP</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for r in registros %}
-        <tr>
-          <td>{{ loop.index }}</td>
-          <td>{{ r.nombre }} {{ r.apellidos }}</td>
-          <td>{{ r.email }}</td>
-          <td>{{ r.telefono or "" }}</td>
-          <td>{{ r.institucion or "" }}</td>
-          <td>{{ r.carrera_o_area or "" }}</td>
-          <td>{{ "Sí" if r.consentimiento else "No" }}</td>
-          <td>{{ r.asistencia_marcarda_en }}</td>
-          <td>{{ r.creado_en }}</td>
-          <td>{{ r.ip or "" }}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
   </div>
-  {% elif slug %}
-    <div class="alert alert-info">No hay registros para este evento.</div>
-  {% endif %}
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- align admin login form with card layout and use primary submit button
- wrap admin panel filters and table in a card container

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689e88aa348c832294766d8e93c58ced