### PR TITLE
Style success page with centered card

### DIFF
--- a/templates/success.html
+++ b/templates/success.html
@@ -1,7 +1,14 @@
 {% extends "base.html" %}
 {% block content %}
-<div class="text-center">
-  <h1 class="h4">¡Gracias! Tu asistencia ha sido registrada.</h1>
-  <p class="text-muted">Revisa tu correo (si corresponde) para cualquier confirmación adicional.</p>
+<div class="row justify-content-center">
+  <div class="col-md-8 col-lg-6">
+    <div class="card shadow-sm">
+      <div class="card-body text-center">
+        <h1 class="h4">¡Gracias! Tu asistencia ha sido registrada.</h1>
+        <p class="text-muted">Revisa tu correo (si corresponde) para cualquier confirmación adicional.</p>
+        <a href="/" class="btn btn-primary mt-3">Nueva asistencia</a>
+      </div>
+    </div>
+  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Center success message within a card to match form layout
- Add "Nueva asistencia" button for easy navigation

## Testing
- `python -m py_compile app.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e8999004883229580412fca70257c