### PR TITLE
feat: track teacher interest topics

### DIFF
--- a/app.py
+++ b/app.py
@@ -69,6 +69,7 @@ def api_registro():
     telefono = (data.get("telefono") or "").strip()
     institucion = (data.get("institucion") or "").strip()
     carrera = (data.get("carrera_o_area") or "").strip()
+    temas = (data.get("temas_interes") or "").strip()
     consentimiento = 1 if str(data.get("consentimiento", "0")) in ("1", "true", "on") else 0
 
     ip = request.headers.get("X-Forwarded-For", request.remote_addr)
@@ -90,10 +91,10 @@ def api_registro():
     try:
         cur.execute("""
             INSERT INTO registro
-            (id_evento, nombre, apellidos, email, telefono, institucion, carrera_o_area,
+            (id_evento, nombre, apellidos, email, telefono, institucion, carrera_o_area, temas_interes,
              consentimiento, asistencia_marcarda_en, ip, user_agent)
-            VALUES (%s,%s,%s,%s,%s,%s,%s,%s, NOW(), %s,%s)
-        """, (id_evento, nombre, apellidos, email, telefono, institucion, carrera, consentimiento, ip, ua))
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s, NOW(), %s,%s)
+        """, (id_evento, nombre, apellidos, email, telefono, institucion, carrera, temas, consentimiento, ip, ua))
         cnx.commit()
     except mysql.connector.Error as e:
         cur.close(); cnx.close()
@@ -160,7 +161,7 @@ def admin_export():
     cur = cnx.cursor(dictionary=True)
     cur.execute("""
         SELECT e.slug, e.titulo, r.nombre, r.apellidos, r.email, r.telefono,
-               r.institucion, r.carrera_o_area, r.consentimiento, r.asistencia_marcarda_en, r.creado_en
+               r.institucion, r.carrera_o_area, r.temas_interes, r.consentimiento, r.asistencia_marcarda_en, r.creado_en
         FROM registro r
         JOIN evento e ON e.id = r.id_evento
         WHERE e.slug=%s
@@ -172,10 +173,10 @@ def admin_export():
     output = io.StringIO()
     writer = csv.writer(output)
     writer.writerow(["slug","titulo","nombre","apellidos","email","telefono","institucion",
-                     "carrera_o_area","consentimiento","asistencia_marcarda_en","creado_en"])
+                     "carrera_o_area","temas_interes","consentimiento","asistencia_marcarda_en","creado_en"])
     for r in rows:
         writer.writerow([r["slug"], r["titulo"], r["nombre"], r["apellidos"], r["email"], r["telefono"],
-                         r["institucion"], r["carrera_o_area"], r["consentimiento"],
+                         r["institucion"], r["carrera_o_area"], r["temas_interes"], r["consentimiento"],
                          r["asistencia_marcarda_en"], r["creado_en"]])
     csv_data = output.getvalue().encode("utf-8-sig")  # BOM para Excel
     resp = make_response(csv_data)

--- a/schema.sql
+++ b/schema.sql
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS registro (
   telefono VARCHAR(30) NULL,
   institucion VARCHAR(180) NULL,
   carrera_o_area VARCHAR(180) NULL,
+  temas_interes TEXT NULL,
   consentimiento TINYINT(1) NOT NULL DEFAULT 0,
   asistencia_marcarda_en DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   ip VARCHAR(45) NULL,

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -86,6 +86,7 @@
               <th>Teléfono</th>
               <th>Institución</th>
               <th>Carrera/Área</th>
+              <th>Temas de interés</th>
               <th>Consent.</th>
               <th>Asistencia</th>
               <th>Registrado</th>
@@ -101,6 +102,7 @@
               <td>{{ r.telefono or "" }}</td>
               <td>{{ r.institucion or "" }}</td>
               <td>{{ r.carrera_o_area or "" }}</td>
+              <td>{{ r.temas_interes or "" }}</td>
               <td>{{ "Sí" if r.consentimiento else "No" }}</td>
               <td>{{ r.asistencia_marcarda_en }}</td>
               <td>{{ r.creado_en }}</td>

--- a/templates/form.html
+++ b/templates/form.html
@@ -39,6 +39,10 @@
               <input class="form-control" name="carrera_o_area" />
             </div>
             <div class="col-12">
+              <label class="form-label">Temas de actualización docente de interés</label>
+              <textarea class="form-control" name="temas_interes" rows="3"></textarea>
+            </div>
+            <div class="col-12">
               <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="cons" name="consentimiento" />
                 <label class="form-check-label" for="cons">


### PR DESCRIPTION
## Summary
- add `temas_interes` textarea to registration form
- persist teacher interest topics and expose them in admin table and CSV export

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689f6b7920508322b3d5292110d9a6ee