### PR TITLE
Handle non-JSON responses for registration

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -28,6 +28,13 @@
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
       });
+      const contentType = res.headers.get("content-type") || "";
+      if (!contentType.includes("application/json")) {
+        const text = await res.text();
+        const errMsg = text || `Respuesta no JSON (Content-Type: ${contentType})`;
+        msg.innerHTML = `<div class="alert alert-danger">${errMsg}</div>`;
+        return;
+      }
       const data = await res.json();
 
       if (!res.ok || !data.ok) {


### PR DESCRIPTION
## Summary
- Validate response Content-Type before parsing JSON
- Show server response text when Content-Type is not JSON

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4ffd351d48322ae78b5816c866827