### PR TITLE
Add dynamic default event slug

### DIFF
--- a/templates/no_event.html
+++ b/templates/no_event.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>No hay un evento activo</h1>
+<p>Por favor, vuelva más tarde.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Resolve default event slug from environment or latest active event
- Show info page when no active event exists

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5044cdfbc8322bd53f8d725adec8b