### PR TITLE
Usa url_for para enlaces a la portada

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -273,7 +273,7 @@
 <body class="bg-light">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container">
-      <a class="navbar-brand" href="/">Asistencia QR</a>
+        <a class="navbar-brand" href="{{ url_for('index') }}">Asistencia QR</a>
       <div class="ms-auto">
         <a class="btn btn-outline-light btn-sm" href="{{ url_for('admin_panel') }}">
           <i class="fas fa-user-shield me-2"></i>Admin

--- a/templates/success.html
+++ b/templates/success.html
@@ -6,7 +6,7 @@
       <div class="card-body text-center">
         <h1 class="h4">¡Gracias! Tu asistencia ha sido registrada.</h1>
         <p class="text-muted">Revisa tu correo (si corresponde) para cualquier confirmación adicional.</p>
-        <a href="/" class="btn btn-primary mt-3">Nueva asistencia</a>
+          <a href="{{ url_for('index') }}" class="btn btn-primary mt-3">Nueva asistencia</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Reemplaza enlaces directos a `/` por `url_for('index')` en las plantillas
- Unifica el patrón para acceder a la portada

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a51ab3ef488322be4929dfc99aab05