### PR TITLE
Use url_for for navbar brand link

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -273,7 +273,7 @@
 <body class="bg-light">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container">
-      <a class="navbar-brand" href="/">Asistencia QR</a>
+      <a class="navbar-brand" href="{{ url_for('index') }}">Asistencia QR</a>
       <div class="ms-auto">
         <a class="btn btn-outline-light btn-sm" href="{{ url_for('admin_panel') }}">
           <i class="fas fa-user-shield me-2"></i>Admin


### PR DESCRIPTION
## Summary
- Use `url_for('index')` for the navbar brand link so home navigation works when the app is mounted at a subpath

## Testing
- `python -m pytest`
- Verified rendered navbar brand uses `/subpath/` when `APPLICATION_ROOT` is set

------
https://chatgpt.com/codex/tasks/task_e_68a6b2bec5088322934e7ecb41c8c1f5