### PR TITLE
Use url_for for success page home link

### DIFF
--- a/templates/success.html
+++ b/templates/success.html
@@ -6,7 +6,7 @@
       <div class="card-body text-center">
         <h1 class="h4">¡Gracias! Tu asistencia ha sido registrada.</h1>
         <p class="text-muted">Revisa tu correo (si corresponde) para cualquier confirmación adicional.</p>
-        <a href="/" class="btn btn-primary mt-3">Nueva asistencia</a>
+        <a href="{{ url_for('index') }}" class="btn btn-primary mt-3">Nueva asistencia</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- use Flask's `url_for` in `success.html` so the "Nueva asistencia" button respects application prefixes

## Testing
- `pytest`
- `python - <<'PY'
from flask import render_template
from app import app
with app.test_request_context('/', environ_overrides={'SCRIPT_NAME':'/pref'}):
    rendered = render_template('success.html')
    for line in rendered.splitlines():
        if 'Nueva asistencia' in line:
            print(line)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a6b37f869483228bc1374f250a94c9