### PR TITLE
Use data attributes for API and redirect URLs

### DIFF
--- a/app.py
+++ b/app.py
@@ -142,6 +142,10 @@ def api_registro():
         if cnx:
             cnx.close()
 
+@app.get("/success")
+def success():
+    return render_template("success.html")
+
 # ------- Admin --------
 
 @app.get("/admin/login")

--- a/static/app.js
+++ b/static/app.js
@@ -3,6 +3,8 @@
   if (!form) return;
 
   const msg = document.getElementById("msg");
+  const apiUrl = form.dataset.api;
+  const successUrl = form.dataset.success;
 
   form.addEventListener("submit", async (e) => {
     e.preventDefault();
@@ -23,7 +25,7 @@
     payload["consentimiento"] = formData.get("consentimiento") ? 1 : 0;
 
     try {
-      const res = await fetch("/api/registro", {
+      const res = await fetch(apiUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
@@ -46,8 +48,10 @@
       // Éxito
       msg.innerHTML = `<div class="alert alert-success">¡Asistencia registrada! 🎉</div>`;
       form.reset();
-      // Si prefieres, redirige:
-      // window.location.href = "/success";
+      if (successUrl) {
+        window.location.href = successUrl;
+        return;
+      }
     } catch (err) {
       msg.innerHTML = `<div class="alert alert-danger">Error de red: ${String(err)}</div>`;
     }

--- a/templates/form.html
+++ b/templates/form.html
@@ -10,7 +10,7 @@
           {% if evento.fecha_inicio %} • {{ evento.fecha_inicio }}{% endif %}
         </p>
 
-        <form id="formRegistro" novalidate>
+        <form id="formRegistro" data-api="{{ url_for('api_registro') }}" data-success="{{ url_for('success') }}" novalidate>
           <input type="hidden" name="slug" value="{{ evento.slug }}" />
 
           <div class="row g-3">


### PR DESCRIPTION
## Summary
- Provide API and success redirect URLs via data attributes in the registration form
- Use those dynamic URLs in the frontend to submit and optionally redirect
- Add a `/success` route serving the success page

## Testing
- `node --check static/app.js`
- `python -m py_compile app.py && echo 'py_compile success'`
- `python - <<'PY'
from app import app
from flask import url_for

app.config['APPLICATION_ROOT'] = '/pref'
with app.test_request_context():
    print('API URL:', url_for('api_registro'))
    print('Success URL:', url_for('success'))

with app.test_client() as client:
    resp = client.get('/success', environ_overrides={'SCRIPT_NAME': '/pref'})
    print('GET /success with prefix status:', resp.status_code)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a6b499728c8322855970c162a8d5de