### PR TITLE
Maneja ausencia de eventos activos

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,7 +46,7 @@ def db_conn():
 
 
 def get_default_slug():
-    """Return slug of the active event or raise a clear error if none is active."""
+    """Return slug of the active event or ``None`` if none is active."""
     cnx = cur = None
     try:
         cnx = db_conn()
@@ -55,10 +55,7 @@ def get_default_slug():
             "SELECT slug FROM evento WHERE activo=1 ORDER BY creado_en DESC LIMIT 1"
         )
         row = cur.fetchone()
-        if not row:
-            # 500 to signal misconfiguration; admin must create/activate an event
-            abort(500, description="No hay un evento activo. Crea y/o activa un evento desde Admin > Eventos.")
-        return row["slug"]
+        return row["slug"] if row else None
     finally:
         if cur:
             cur.close()
@@ -76,7 +73,9 @@ def admin_required(f):
 @app.get("/")
 def index():
     slug = get_default_slug()
-    return redirect(url_for("evento_form", slug=slug))
+    if slug:
+        return redirect(url_for("evento_form", slug=slug))
+    return render_template("no_event.html")
 
 @app.get("/evento/<slug>")
 def evento_form(slug):

--- a/templates/no_event.html
+++ b/templates/no_event.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
 {% block content %}
-<h1>No hay un evento activo</h1>
-<p>Por favor, vuelva más tarde.</p>
+<h1>Por el momento no hay eventos activos</h1>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Evita error 500 cuando no hay eventos activos retornando `None` en `get_default_slug`
- Muestra una página sin eventos en la raíz si no hay evento activo
- Ajusta plantilla `no_event.html` con mensaje actualizado

## Testing
- `python -m py_compile app.py`
- `pytest 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68aaa7effb348322a7e976869b03f75b