### PR TITLE
Add admin route to deactivate events

### DIFF
--- a/app.py
+++ b/app.py
@@ -285,6 +285,23 @@ def admin_evento_activar(event_id: int):
         cur.close(); cnx.close()
     return redirect(url_for("admin_panel"))
 
+
+@app.post("/admin/evento/<int:event_id>/desactivar")
+@admin_required
+def admin_evento_desactivar(event_id: int):
+    cnx = db_conn()
+    cur = cnx.cursor()
+    try:
+        cur.execute("UPDATE evento SET activo=0 WHERE id=%s", (event_id,))
+        cnx.commit()
+        flash("Evento desactivado", "success")
+    except mysql.connector.Error as e:
+        cnx.rollback()
+        flash(f"Error de BD: {e}", "danger")
+    finally:
+        cur.close(); cnx.close()
+    return redirect(url_for("admin_panel"))
+
 @app.get("/admin/export")
 @admin_required
 def admin_export():

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -193,16 +193,18 @@
                 {% endif %}
               </td>
               <td>
-                {% if not e.activo %}
+                {% if e.activo %}
+                  <form method="post" action="{{ url_for('admin_evento_desactivar', event_id=e.id) }}" class="d-inline">
+                    <button class="btn btn-sm btn-outline-danger" type="submit">
+                      <i class="fas fa-stop"></i> Desactivar
+                    </button>
+                  </form>
+                {% else %}
                   <form method="post" action="{{ url_for('admin_evento_activar', event_id=e.id) }}" class="d-inline">
                     <button class="btn btn-sm btn-outline-success" type="submit">
                       <i class="fas fa-play"></i> Activar
                     </button>
                   </form>
-                {% else %}
-                  <button class="btn btn-sm btn-outline-secondary" disabled>
-                    <i class="fas fa-check"></i> Activo
-                  </button>
                 {% endif %}
               </td>
             </tr>


### PR DESCRIPTION
## Summary
- allow admins to deactivate events via new `/admin/evento/<int:event_id>/desactivar` route
- enable toggling event activation state from the admin panel with clear Activate/Deactivate buttons

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aaa8ea014483229208c6bb95ec356e