### PR TITLE
Add return-later subtitle to no event template

### DIFF
--- a/templates/no_event.html
+++ b/templates/no_event.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Por el momento no hay eventos activos</h1>
+<p class="text-center text-muted">Vuelva más tarde</p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show a message when there are no active events and ask users to return later
- keep the no-event template extending the shared base layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aaa9dfc0388322b49fc04f311b21a2