### PR TITLE
Add dark theme palette and component styles

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -1,32 +1,50 @@
 /* Minimal, professional look layered on top of Bootstrap */
 
 :root {
-	--radius: 12px;
-	--border: #e6e8ec;
-	--muted: #6c757d;
-	--text: #212529;
-	--ring-rgb: 13, 110, 253; /* Bootstrap primary */
+        --radius: 12px;
+        --border: #e6e8ec;
+        --muted: #6c757d;
+        --text: #212529;
+        --ring-rgb: 13, 110, 253; /* Bootstrap primary */
+}
+
+:root[data-theme="dark"] {
+        --border: #374151;
+        --muted: #9ca3af;
+        --text: #f3f4f6;
+        --ring-rgb: 59, 130, 246; /* brighter blue for dark mode */
 }
 
 /* Base */
 body {
-	min-height: 100vh;
-	color: var(--text);
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
+        min-height: 100vh;
+        color: var(--text);
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+}
+
+body[data-theme="dark"] {
+        background-color: #111827;
+        color: var(--text);
 }
 
 .navbar-brand { font-weight: 600; letter-spacing: .2px; }
 
 /* Cards */
 .card {
-	border-radius: var(--radius);
-	border: 1px solid var(--border);
-	box-shadow: 0 2px 10px rgba(17, 24, 39, .06);
+        border-radius: var(--radius);
+        border: 1px solid var(--border);
+        box-shadow: 0 2px 10px rgba(17, 24, 39, .06);
 }
 .card .card-body {
-	padding: 1.25rem;
+        padding: 1.25rem;
  }
+
+body[data-theme="dark"] .card {
+        background-color: #1f2937;
+        border-color: var(--border);
+        box-shadow: 0 2px 10px rgba(0, 0, 0, .6);
+}
 @media (min-width: 768px) {
 	.card .card-body { padding: 2rem; }
 }
@@ -114,15 +132,52 @@ body {
 
 /* Tables (admin) */
 .table thead th {
-	font-size: .75rem;
-	text-transform: uppercase;
+        font-size: .75rem;
+        text-transform: uppercase;
 	letter-spacing: .04em;
 	color: var(--muted);
 	background: #f8f9fa;
 }
 .table td, .table th { vertical-align: middle; }
 
+/* Dark theme overrides */
+body[data-theme="dark"] .form-control,
+body[data-theme="dark"] .form-select {
+        background-color: #1f2937;
+        border-color: var(--border);
+        color: var(--text);
+}
+
+body[data-theme="dark"] .form-control::placeholder {
+        color: #9ca3af;
+}
+
+body[data-theme="dark"] .form-check-input {
+        background-color: #1f2937;
+        border-color: var(--border);
+}
+
+body[data-theme="dark"] .alert {
+        background-color: #1f2937;
+        border-color: var(--border);
+        color: var(--text);
+}
+
+body[data-theme="dark"] .table {
+        color: var(--text);
+}
+
+body[data-theme="dark"] .table thead th {
+        background: #1f2937;
+        color: var(--muted);
+}
+
+body[data-theme="dark"] .table td,
+body[data-theme="dark"] .table th {
+        border-color: var(--border);
+}
+
 /* Utility: subtle container spacing tightness on narrow screens */
 @media (max-width: 575.98px) {
-	main.container { padding-left: 1rem !important; padding-right: 1rem !important; }
+        main.container { padding-left: 1rem !important; padding-right: 1rem !important; }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,10 +19,26 @@
       --shadow-medium: 0 4px 20px rgba(0, 0, 0, 0.15);
     }
 
+    :root[data-theme="dark"] {
+      --primary-color: #3b82f6;
+      --secondary-color: #1e40af;
+      --accent-color: #1f2937;
+      --text-primary: #f3f4f6;
+      --text-secondary: #cbd5e1;
+      --border-color: #374151;
+      --shadow-light: 0 2px 10px rgba(0, 0, 0, 0.6);
+      --shadow-medium: 0 4px 20px rgba(0, 0, 0, 0.8);
+    }
+
     body {
       background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       min-height: 100vh;
+      color: var(--text-primary);
+    }
+
+    body[data-theme="dark"] {
+      background: linear-gradient(135deg, #1f2937 0%, #111827 100%);
       color: var(--text-primary);
     }
 
@@ -257,13 +273,73 @@
       color: var(--secondary-color);
     }
 
-    /* Indicadores de campos requeridos */
-    .required::after {
-      content: ' *';
-      color: #dc3545;
-      font-weight: bold;
-    }
-  </style>
+      /* Indicadores de campos requeridos */
+      .required::after {
+        content: ' *';
+        color: #dc3545;
+        font-weight: bold;
+      }
+      /* Dark theme overrides */
+      body[data-theme="dark"] .form-section {
+        background: var(--accent-color);
+        color: var(--text-primary);
+        box-shadow: var(--shadow-light);
+        border-left: 4px solid var(--secondary-color);
+      }
+
+      body[data-theme="dark"] .form-control,
+      body[data-theme="dark"] .form-select {
+        background: #1f2937;
+        border: 2px solid var(--border-color);
+        color: var(--text-primary);
+      }
+
+      body[data-theme="dark"] .form-control:focus,
+      body[data-theme="dark"] .form-select:focus {
+        background: #111827;
+        border-color: var(--secondary-color);
+        box-shadow: 0 0 0 0.2rem rgba(30, 64, 175, 0.35);
+      }
+
+      body[data-theme="dark"] .alert {
+        background: var(--accent-color);
+        color: var(--text-primary);
+        box-shadow: var(--shadow-light);
+      }
+
+      body[data-theme="dark"] .alert-success {
+        background: linear-gradient(135deg, #065f46 0%, #047857 100%);
+        color: #d1fae5;
+        border-left-color: #10b981;
+      }
+
+      body[data-theme="dark"] .alert-danger {
+        background: linear-gradient(135deg, #7f1d1d 0%, #b91c1c 100%);
+        color: #fee2e2;
+        border-left-color: #ef4444;
+      }
+
+      body[data-theme="dark"] .footer-info {
+        background: var(--accent-color);
+        color: var(--text-secondary);
+        box-shadow: var(--shadow-light);
+      }
+
+      body[data-theme="dark"] .table {
+        color: var(--text-primary);
+      }
+
+      body[data-theme="dark"] .table thead th {
+        background: #1f2937;
+        color: var(--text-secondary);
+      }
+
+      body[data-theme="dark"] .table td,
+      body[data-theme="dark"] .table th {
+        border-color: var(--border-color);
+      }
+
+    </style>
 </head>
 <body class="bg-light">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark">


### PR DESCRIPTION
## Summary
- Introduce dark theme CSS variables for consistent palette across templates.
- Add dark-mode overrides for forms, cards, alerts, and admin tables.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aba5ec14b08322a445ecc877daacc8