### PR TITLE
Add theme toggle button in navbar

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -57,3 +57,25 @@
     }
   });
 })();
+
+(function () {
+  const toggle = document.getElementById("themeToggle");
+  if (!toggle) return;
+  const root = document.documentElement;
+  const body = document.body;
+
+  function setTheme(theme) {
+    root.setAttribute("data-theme", theme);
+    body.setAttribute("data-theme", theme);
+    toggle.innerHTML = theme === "dark" ? '<i class="fas fa-sun"></i>' : '<i class="fas fa-moon"></i>';
+  }
+
+  const saved = localStorage.getItem("theme") || "light";
+  setTheme(saved);
+
+  toggle.addEventListener("click", () => {
+    const next = root.getAttribute("data-theme") === "dark" ? "light" : "dark";
+    setTheme(next);
+    localStorage.setItem("theme", next);
+  });
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -345,7 +345,10 @@
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container">
       <a class="navbar-brand" href="{{ url_for('index') }}">Asistencia QR</a>
-      <div class="ms-auto">
+      <div class="ms-auto d-flex align-items-center">
+        <button id="themeToggle" class="btn btn-outline-light btn-sm me-2" aria-label="Cambiar tema">
+          <i class="fas fa-moon"></i>
+        </button>
         <a class="btn btn-outline-light btn-sm" href="{{ url_for('admin_panel') }}">
           <i class="fas fa-user-shield me-2"></i>Admin
         </a>


### PR DESCRIPTION
## Summary
- Add Bootstrap-styled theme toggle button with accessible label in navbar
- Implement JavaScript to switch between light and dark themes and update icon

## Testing
- `python -m py_compile app.py wsgi.py`


------
https://chatgpt.com/codex/tasks/task_e_68abce29e16c8322b3622fe1f029602f