### PR TITLE
feat: add theme toggle with system preference fallback

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -70,7 +70,12 @@
     toggle.innerHTML = theme === "dark" ? '<i class="fas fa-sun"></i>' : '<i class="fas fa-moon"></i>';
   }
 
-  const saved = localStorage.getItem("theme") || "light";
+  let saved = localStorage.getItem("theme");
+  if (!saved) {
+    saved = window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  }
   setTheme(saved);
 
   toggle.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- initialize theme using stored preference or system color scheme
- toggle light/dark modes and persist selection

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abd486e1bc8322911341a953898602